### PR TITLE
feat: introduce solution for rendering Chinese punctuation marks

### DIFF
--- a/examples/src/styles/main.css
+++ b/examples/src/styles/main.css
@@ -1,5 +1,1 @@
 @import "variables.css";
-
-html.dark {
-  //background: #22272e;
-}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,3 @@
+import type { FontType } from "./types";
+
+export const fontType: FontType[] = ["chinese", "helvetica", "italics", "song", "imitation-song", "new-song", "li"];

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,17 +1,19 @@
-const macosSimplifiedChinese = ["-apple-system", "BlinkMacSystemFont", "PingFang SC", "Hiragino Sans GB", "Heiti SC"];
-const macosTraditionalChinese = ["-apple-system", "BlinkMacSystemFont", "PingFang SC"];
-const windowsSimplifiedChinese = ["Microsoft YaHei"];
-const windowsTraditionalChinese = ["Microsoft Jhenghei"];
-const linuxSimplifiedChinese = ["system-ui", "Ubuntu", "Droid Sans", "Source Han Sans SC", "Source Han Sans CN", "Source Han Sans"];
-const linuxTraditionalChinese = ["system-ui", "Ubuntu", "Droid Sans", "Source Han Sans TC", "Source Han Sans TW", "Source Han Sans"];
+import { fontType } from "./constants";
+import type { ChineseType, FontType } from "./types";
 
-export type FontType = "chinese" | "helvetica" | "italics" | "song" | "imitation-song" | "new-song" | "li";
+export const macosSimplifiedChinese = ["-apple-system", "BlinkMacSystemFont", "PingFang SC", "Hiragino Sans GB", "Heiti SC"];
+export const macosTraditionalChinese = ["-apple-system", "BlinkMacSystemFont", "PingFang SC"];
+export const windowsSimplifiedChinese = ["Microsoft YaHei"];
+export const windowsTraditionalChinese = ["Microsoft Jhenghei"];
+export const linuxSimplifiedChinese = ["system-ui", "Ubuntu", "Droid Sans", "Source Han Sans SC", "Source Han Sans CN", "Source Han Sans"];
+export const linuxTraditionalChinese = ["system-ui", "Ubuntu", "Droid Sans", "Source Han Sans TC", "Source Han Sans TW", "Source Han Sans"];
+
 /**
  * Generates a list of fonts for the specified character type and font type, with optional fallback font.
  * 根据指定的字符类型和字体类型生成字体列表，可以选择性地指定回退字体。
  *
- * @param characterType - The type of characters to consider: "simplified" or "traditional".
- *                       要考虑的字符类型："simplified"（简体）或 "traditional"（繁体）。
+ * @param chineseType - The type of chinese: "simplified" or "traditional".
+ *                       要考虑的汉字类型："simplified"（简体）或 "traditional"（繁体）。
  * @param fontType - The type of font to generate the list for: "chinese", "helvetica", "italics", "song", "imitation-song", "new-song", or "li".
  *                  要生成列表的字体类型："chinese"、"helvetica"、"italics"、"song"、"imitation-song"、"new-song" 或 "li"。
  * @param fallbackFont - The fallback font to use if the desired font type is not available. Pass `null` for no fallback.
@@ -23,21 +25,21 @@ export type FontType = "chinese" | "helvetica" | "italics" | "song" | "imitation
  *                    基于指定条件的字体名称数组。
  */
 export function generateFontList(
-  characterType: "simplified" | "traditional",
+  chineseType: ChineseType,
   fontType: FontType,
-  fallbackFont: string | null = "sans-serif",
-  declareEnglishFont: boolean = true,
+  fallbackFont: string[] | null = ["sans-serif"],
+  declareEnglishFont: string[] = ["Arial"],
 ): string[] {
   const fontList: string[] = [];
 
   // Add English font declaration if required
-  if (declareEnglishFont) {
-    fontList.push(`Punctuation ${fontType.charAt(0).toUpperCase() + fontType.slice(1)}`);
-    fontList.push("Arial");
+  if (declareEnglishFont.length > 0) {
+    fontList.push(generatePunctuationFontName(fontType));
+    fontList.push(...declareEnglishFont);
   }
 
   // Determine the appropriate font list based on the character type
-  if (characterType === "simplified") {
+  if (chineseType === "simplified") {
     const chineseFonts = [macosSimplifiedChinese, windowsSimplifiedChinese, linuxSimplifiedChinese].flat();
     // Select the font list based on the font type
     switch (fontType) {
@@ -153,28 +155,16 @@ export function generateFontList(
 
   // Add fallback font if specified
   if (fallbackFont !== null) {
-    fontList.push(fallbackFont);
+    fontList.push(...fallbackFont);
   }
 
   return fontList;
 }
 
-export const defaultChineseFonts = {
-
-  "chinese": generateFontList("simplified", "chinese"),
-  // 黑体
-  "helvetica": generateFontList("simplified", "helvetica"),
-  // 楷体
-  "italics": generateFontList("simplified", "italics"),
-  // 宋体
-  "song": generateFontList("simplified", "song"),
-  // 仿宋体
-  "imitation-song": generateFontList("simplified", "imitation-song"),
-  // 新宋体
-  "new-song": generateFontList("simplified", "new-song"),
-  // 隶书
-  "li": generateFontList("simplified", "li"),
-};
+export const defaultChineseFonts: Record<FontType, string[]> = fontType.reduce((fonts, type) => {
+  fonts[type] = generateFontList("simplified", type);
+  return fonts;
+}, {} as Record<FontType, string[]>);
 
 /**
  * Generates a CSS @font-face rule for the specified font type.
@@ -182,18 +172,20 @@ export const defaultChineseFonts = {
  *
  * @param fontType - The type of font to generate the @font-face rule for.
  *                  要生成 @font-face 规则的字体类型。
- *
+ * @param {string[]} filterFontList - The list of fonts to be filtered out from the default font list.
+ *                                  要从默认字体列表中过滤掉的字体列表。
  * @returns {string} The generated @font-face CSS rule as a string.
  *                   生成的 @font-face CSS 规则作为字符串。
  */
-export function generateFontFaceRule(fontType: FontType): string {
+export function generateFontFaceRule(fontType: FontType, filterFontList: string[]): string {
   const fontList = defaultChineseFonts[fontType];
   if (!fontList) {
     throw new Error(`Font type "${fontType}" is not valid.`);
   }
 
-  const fontName = `Punctuation ${fontType.charAt(0).toUpperCase() + fontType.slice(1)}`;
-  const filteredFontList = fontList.filter(font => font !== "Arial"); // Filtering out Arial
+  const fontName = generatePunctuationFontName(fontType);
+  // Filtering out specified fonts
+  const filteredFontList = fontList.filter(font => !filterFontList.includes(font));
   const fontSrc = filteredFontList.map(font => `local('${font}')`).join(", ");
 
   return `
@@ -203,4 +195,7 @@ export function generateFontFaceRule(fontType: FontType): string {
   unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F; 
 }
 `;
+}
+export function generatePunctuationFontName(fontType: FontType): string {
+  return `Punctuation ${fontType.charAt(0).toUpperCase() + fontType.slice(1)}`;
 }

--- a/src/defaultChineseFonts.ts
+++ b/src/defaultChineseFonts.ts
@@ -1,111 +1,206 @@
+const macosSimplifiedChinese = ["-apple-system", "BlinkMacSystemFont", "PingFang SC", "Hiragino Sans GB", "Heiti SC"];
+const macosTraditionalChinese = ["-apple-system", "BlinkMacSystemFont", "PingFang SC"];
+const windowsSimplifiedChinese = ["Microsoft YaHei"];
+const windowsTraditionalChinese = ["Microsoft Jhenghei"];
+const linuxSimplifiedChinese = ["system-ui", "Ubuntu", "Droid Sans", "Source Han Sans SC", "Source Han Sans CN", "Source Han Sans"];
+const linuxTraditionalChinese = ["system-ui", "Ubuntu", "Droid Sans", "Source Han Sans TC", "Source Han Sans TW", "Source Han Sans"];
+
+export type FontType = "chinese" | "helvetica" | "italics" | "song" | "imitation-song" | "new-song" | "li";
+/**
+ * Generates a list of fonts for the specified character type and font type, with optional fallback font.
+ * 根据指定的字符类型和字体类型生成字体列表，可以选择性地指定回退字体。
+ *
+ * @param characterType - The type of characters to consider: "simplified" or "traditional".
+ *                       要考虑的字符类型："simplified"（简体）或 "traditional"（繁体）。
+ * @param fontType - The type of font to generate the list for: "chinese", "helvetica", "italics", "song", "imitation-song", "new-song", or "li".
+ *                  要生成列表的字体类型："chinese"、"helvetica"、"italics"、"song"、"imitation-song"、"new-song" 或 "li"。
+ * @param fallbackFont - The fallback font to use if the desired font type is not available. Pass `null` for no fallback.
+ *                      如果所需字体类型不可用，则使用的回退字体。传递 `null` 表示没有回退字体。
+ * @param declareEnglishFont - Whether to declare an English font.
+ *                             是否声明英文字体。
+ *
+ * @returns {string[]} An array of font names based on the specified criteria.
+ *                    基于指定条件的字体名称数组。
+ */
+export function generateFontList(
+  characterType: "simplified" | "traditional",
+  fontType: FontType,
+  fallbackFont: string | null = "sans-serif",
+  declareEnglishFont: boolean = true,
+): string[] {
+  const fontList: string[] = [];
+
+  // Add English font declaration if required
+  if (declareEnglishFont) {
+    fontList.push(`Punctuation ${fontType.charAt(0).toUpperCase() + fontType.slice(1)}`);
+    fontList.push("Arial");
+  }
+
+  // Determine the appropriate font list based on the character type
+  if (characterType === "simplified") {
+    const chineseFonts = [macosSimplifiedChinese, windowsSimplifiedChinese, linuxSimplifiedChinese].flat();
+    // Select the font list based on the font type
+    switch (fontType) {
+      case "chinese":
+        fontList.push(...chineseFonts);
+        break;
+        // 黑体
+      case "helvetica":
+        fontList.push("PingFang SC", "Heiti SC", "Microsoft YaHei", "Source Han Sans SC", "Source Han Sans CN", "Noto Sans CJK SC",
+          "WenQuanYi Micro Hei", "WenQuanYi Zen Hei", "SimHei", "WenQuanYi Zen Hei Sharp");
+        break;
+        // 楷体
+      case "italics":
+        fontList.push("Kaiti SC", "STKaiti",
+          "AR PL UKai CN", "AR PL UKai HK", "AR PL UKai TW", "AR PL UKai TW MBE", "AR PL KaitiM GB",
+          "KaiTi", "KaiTi_GB2312", "DFKai-SB");
+        fontList.push(...chineseFonts);
+        break;
+        // 宋体
+      case "song":
+        fontList.push("Songti SC", "Noto Serif CJK SC",
+          "Source Han Serif SC",
+          "Source Han Serif CN",
+          "STSong",
+          "AR PL New Sung",
+          "AR PL SungtiL GB",
+          "NSimSun",
+          "SimSun",
+          "WenQuanYi Bitmap Song",
+          "AR PL UMing CN",
+          "PMingLiU",
+          "MingLiU",
+        );
+        fontList.push(...chineseFonts);
+        break;
+        // 仿宋体
+      case "imitation-song":
+        fontList.push("STFangsong", "FangSong", "FangSong_GB2312");
+        fontList.push(...chineseFonts);
+        break;
+        // 新宋体
+      case "new-song":
+        fontList.push("SimSun-ExtB", "NSimSun");
+        fontList.push(...chineseFonts);
+        break;
+        // 隶书
+      case "li":
+        fontList.push("LiSu", "STLiti");
+        fontList.push(...chineseFonts);
+        break;
+      default:
+        fontList.push(...chineseFonts);
+    }
+  } else {
+    const chineseFonts = [macosTraditionalChinese, windowsTraditionalChinese, linuxTraditionalChinese].flat();
+    // Select the font list based on the font type
+    switch (fontType) {
+      case "chinese":
+        fontList.push(...chineseFonts);
+        break;
+        // 黑体
+      case "helvetica":
+        fontList.push("PingFang SC", "Heiti SC", "Microsoft YaHei", "Source Han Sans SC", "Source Han Sans CN", "Noto Sans CJK SC",
+          "WenQuanYi Micro Hei", "WenQuanYi Zen Hei", "SimHei", "WenQuanYi Zen Hei Sharp");
+        break;
+        // 楷体
+      case "italics":
+        fontList.push("Kaiti SC", "STKaiti",
+          "AR PL UKai CN", "AR PL UKai HK", "AR PL UKai TW", "AR PL UKai TW MBE", "AR PL KaitiM GB",
+          "KaiTi", "KaiTi_GB2312", "DFKai-SB", "TW-Kai");
+        fontList.push(...chineseFonts);
+        break;
+        // 宋体
+      case "song":
+        fontList.push("Songti SC", "Noto Serif CJK SC",
+          "Source Han Serif SC",
+          "Source Han Serif CN",
+          "STSong",
+          "AR PL New Sung",
+          "AR PL SungtiL GB",
+          "NSimSun",
+          "SimSun",
+          "TW-Sung",
+          "WenQuanYi Bitmap Song",
+          "AR PL UMing CN",
+          "AR PL UMing HK",
+          "AR PL UMing TW",
+          "AR PL UMing TW MBE",
+          "PMingLiU",
+          "MingLiU",
+        );
+        fontList.push(...chineseFonts);
+        break;
+        // 仿宋体
+      case "imitation-song":
+        fontList.push("STFangsong", "FangSong", "FangSong_GB2312");
+        fontList.push(...chineseFonts);
+        break;
+        // 新宋体
+      case "new-song":
+        fontList.push("SimSun-ExtB", "NSimSun");
+        fontList.push(...chineseFonts);
+        break;
+        // 隶书
+      case "li":
+        fontList.push("LiSu", "STLiti");
+        fontList.push(...chineseFonts);
+        break;
+      default:
+        fontList.push(...chineseFonts);
+    }
+  }
+
+  // Add fallback font if specified
+  if (fallbackFont !== null) {
+    fontList.push(fallbackFont);
+  }
+
+  return fontList;
+}
+
 export const defaultChineseFonts = {
-  "chinese": [
-    "Punctuation SC",
-    "Helvetica Neue",
-    "Helvetica",
-    "Arial",
-    "Microsoft Yahei",
-    "Hiragino Sans GB",
-    "Heiti SC",
-    "WenQuanYi Micro Hei",
-    "sans-serif",
-  ],
+
+  "chinese": generateFontList("simplified", "chinese"),
   // 黑体
-  "helvetica": [
-    "Punctuation SC",
-    "-apple-system",
-    "Noto Sans",
-    "Helvetica Neue",
-    "Helvetica",
-    "Nimbus Sans L",
-    "Arial",
-    "Liberation Sans",
-    "PingFang SC",
-    "Hiragino Sans GB",
-    "Noto Sans CJK SC",
-    "Source Han Sans SC",
-    "Source Han Sans CN",
-    "Microsoft YaHei",
-    "Wenquanyi Micro Hei",
-    "WenQuanYi Zen Hei",
-    "ST Heiti",
-    "SimHei",
-    "WenQuanYi Zen Hei Sharp",
-    "sans-serif",
-  ],
+  "helvetica": generateFontList("simplified", "helvetica"),
   // 楷体
-  "italics": [
-    "Punctuation SC",
-    "Baskerville",
-    "Georgia",
-    "Liberation Serif",
-    "Kaiti SC",
-    "STKaiti",
-    "AR PL UKai CN",
-    "AR PL UKai HK",
-    "AR PL UKai TW",
-    "AR PL UKai TW MBE",
-    "AR PL KaitiM GB",
-    "KaiTi",
-    "KaiTi_GB2312",
-    "DFKai-SB",
-    "TW-Kai",
-    "serif",
-  ],
+  "italics": generateFontList("simplified", "italics"),
   // 宋体
-  "song": [
-    "Punctuation SC",
-    "Georgia",
-    "Nimbus Roman No9 L",
-    "Songti SC",
-    "Noto Serif CJK SC",
-    "Source Han Serif SC",
-    "Source Han Serif CN",
-    "STSong",
-    "AR PL New Sung",
-    "AR PL SungtiL GB",
-    "NSimSun",
-    "SimSun",
-    "TW-Sung",
-    "WenQuanYi Bitmap Song",
-    "AR PL UMing CN",
-    "AR PL UMing HK",
-    "AR PL UMing TW",
-    "AR PL UMing TW MBE",
-    "PMingLiU",
-    "MingLiU",
-    "serif",
-  ],
+  "song": generateFontList("simplified", "song"),
   // 仿宋体
-  "imitation-song": [
-    "Punctuation SC",
-    "Baskerville",
-    "Times New Roman",
-    "Liberation Serif",
-    "STFangsong",
-    "FangSong",
-    "FangSong_GB2312",
-    "CWTEX-F",
-    "serif",
-  ],
+  "imitation-song": generateFontList("simplified", "imitation-song"),
   // 新宋体
-  "new-song": [
-    "Punctuation SC",
-    "SimSun-ExtB",
-    "NSimSun",
-    "Microsoft YaHei UI",
-    "Microsoft YaHei UI Light",
-    "Microsoft YaHei UI Bold",
-    "serif",
-  ],
+  "new-song": generateFontList("simplified", "new-song"),
   // 隶书
-  "li": [
-    "Punctuation SC",
-    "LiSu",
-    "YouYuan",
-    "STXingkai",
-    "Xingkai SC",
-    "PMingLiU-ExtB",
-    "serif",
-  ],
+  "li": generateFontList("simplified", "li"),
 };
+
+/**
+ * Generates a CSS @font-face rule for the specified font type.
+ * 根据指定的字体类型生成 CSS @font-face 规则。
+ *
+ * @param fontType - The type of font to generate the @font-face rule for.
+ *                  要生成 @font-face 规则的字体类型。
+ *
+ * @returns {string} The generated @font-face CSS rule as a string.
+ *                   生成的 @font-face CSS 规则作为字符串。
+ */
+export function generateFontFaceRule(fontType: FontType): string {
+  const fontList = defaultChineseFonts[fontType];
+  if (!fontList) {
+    throw new Error(`Font type "${fontType}" is not valid.`);
+  }
+
+  const fontName = `Punctuation ${fontType.charAt(0).toUpperCase() + fontType.slice(1)}`;
+  const filteredFontList = fontList.filter(font => font !== "Arial"); // Filtering out Arial
+  const fontSrc = filteredFontList.map(font => `local('${font}')`).join(", ");
+
+  return `
+@font-face {
+  font-family: '${fontName}';
+  src: ${fontSrc};
+  unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F; 
+}
+`;
+}

--- a/src/defaultChineseFonts.ts
+++ b/src/defaultChineseFonts.ts
@@ -1,5 +1,6 @@
 export const defaultChineseFonts = {
   "chinese": [
+    "Punctuation SC",
     "Helvetica Neue",
     "Helvetica",
     "Arial",
@@ -11,6 +12,7 @@ export const defaultChineseFonts = {
   ],
   // 黑体
   "helvetica": [
+    "Punctuation SC",
     "-apple-system",
     "Noto Sans",
     "Helvetica Neue",
@@ -33,6 +35,7 @@ export const defaultChineseFonts = {
   ],
   // 楷体
   "italics": [
+    "Punctuation SC",
     "Baskerville",
     "Georgia",
     "Liberation Serif",
@@ -51,6 +54,7 @@ export const defaultChineseFonts = {
   ],
   // 宋体
   "song": [
+    "Punctuation SC",
     "Georgia",
     "Nimbus Roman No9 L",
     "Songti SC",
@@ -74,6 +78,7 @@ export const defaultChineseFonts = {
   ],
   // 仿宋体
   "imitation-song": [
+    "Punctuation SC",
     "Baskerville",
     "Times New Roman",
     "Liberation Serif",
@@ -85,6 +90,7 @@ export const defaultChineseFonts = {
   ],
   // 新宋体
   "new-song": [
+    "Punctuation SC",
     "SimSun-ExtB",
     "NSimSun",
     "Microsoft YaHei UI",
@@ -94,6 +100,7 @@ export const defaultChineseFonts = {
   ],
   // 隶书
   "li": [
+    "Punctuation SC",
     "LiSu",
     "YouYuan",
     "STXingkai",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,29 @@
 import { toArray } from "@unocss/core";
 import type { Preset } from "unocss";
-import type { FontType } from "./defaultChineseFonts";
-import { defaultChineseFonts, generateFontFaceRule } from "./defaultChineseFonts";
-import type { ChineseFontsOptions } from "./types";
+import { fontType } from "./constants";
+import type { ChineseFontsOptions, FontType } from "./types";
+import { defaultChineseFonts, generateFontFaceRule, generateFontList } from "./core";
 
 export * from "./types";
 
 const presetChinese = (options: ChineseFontsOptions = {}): Preset => {
   // 解构参数并提供默认值
-  const { extendTheme = true, themeKey = "fontFamily" } = options;
+  const {
+    extendTheme = true,
+    themeKey = "fontFamily",
+    chineseType = "simplified",
+    fallbackFont = ["sans-serif"],
+    declareEnglishFont = ["Arial"],
+  } = options;
 
   // 合并字体选项
-  const fonts = { ...defaultChineseFonts, ...options?.fonts };
+  const fonts = {
+    ...fontType.reduce((fonts, type) => {
+      fonts[type] = generateFontList(chineseType, type, fallbackFont, declareEnglishFont);
+      return fonts;
+    }, {} as Record<FontType, string[]>),
+    ...options?.fonts,
+  };
 
   // 转换字体选项为字体对象
   const fontObject = Object.fromEntries(
@@ -46,7 +58,7 @@ const presetChinese = (options: ChineseFontsOptions = {}): Preset => {
   }
 
   const fontFacePreflights = Object.keys(defaultChineseFonts).map(fontType => ({
-    getCSS: () => generateFontFaceRule(<FontType>fontType),
+    getCSS: () => generateFontFaceRule(<FontType>fontType, declareEnglishFont),
   }));
 
   preset.preflights = fontFacePreflights;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { toArray } from "@unocss/core";
 import type { Preset } from "unocss";
-import { defaultChineseFonts } from "./defaultChineseFonts";
+import type { FontType } from "./defaultChineseFonts";
+import { defaultChineseFonts, generateFontFaceRule } from "./defaultChineseFonts";
 import type { ChineseFontsOptions } from "./types";
 
 export * from "./types";
@@ -43,24 +44,12 @@ const presetChinese = (options: ChineseFontsOptions = {}): Preset => {
       }
     };
   }
-  //  TODO: Dynamically calculates and sets the font styles for specific Chinese characters based on the selected theme's fonts.
-  //  TODO: 根据所选主题的字体动态计算并设置特定中文字符的字体样式。
-  preset.preflights = [
-    {
-      getCSS: () => `
-      @font-face {
-        font-family: 'Punctuation SC';
-        src: local('PingFang SC'), local('Noto Sans SC'), local('Noto Sans CJK SC'), local('Heiti SC'), local('Microsoft Yahei');
-        unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F; /* Unicode range for punctuation marks */
-      }
-      @font-face {
-        font-family: 'Punctuation TC';
-        src: local('PingFang TC'), local('Noto Sans TC'), local('Noto Sans CJK TC'), local('Heiti TC'), local('Microsoft JhengHei');
-        unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F; /* Unicode range for punctuation marks */
-      }
-    `,
-    },
-  ];
+
+  const fontFacePreflights = Object.keys(defaultChineseFonts).map(fontType => ({
+    getCSS: () => generateFontFaceRule(<FontType>fontType),
+  }));
+
+  preset.preflights = fontFacePreflights;
 
   return preset;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,24 @@ const presetChinese = (options: ChineseFontsOptions = {}): Preset => {
       }
     };
   }
+  //  TODO: Dynamically calculates and sets the font styles for specific Chinese characters based on the selected theme's fonts.
+  //  TODO: 根据所选主题的字体动态计算并设置特定中文字符的字体样式。
+  preset.preflights = [
+    {
+      getCSS: () => `
+      @font-face {
+        font-family: 'Punctuation SC';
+        src: local('PingFang SC'), local('Noto Sans SC'), local('Noto Sans CJK SC'), local('Heiti SC'), local('Microsoft Yahei');
+        unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F; /* Unicode range for punctuation marks */
+      }
+      @font-face {
+        font-family: 'Punctuation TC';
+        src: local('PingFang TC'), local('Noto Sans TC'), local('Noto Sans CJK TC'), local('Heiti TC'), local('Microsoft JhengHei');
+        unicode-range: U+201C, U+201D, U+2018, U+2019, U+2E3A, U+2014, U+2013, U+2026, U+00B7, U+007E, U+002F; /* Unicode range for punctuation marks */
+      }
+    `,
+    },
+  ];
 
   return preset;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,20 +1,56 @@
+/**
+ * Options for configuring Chinese fonts.
+ * 配置中文字体的选项。
+ */
 export interface ChineseFontsOptions {
   /**
    * Extend the theme object
+   * 扩展主题对象
    * @default true
    */
   extendTheme?: boolean;
 
   /**
    * Key for the theme object
+   * 主题对象的键
    *
    * @default 'fontFamily'
    */
   themeKey?: string;
 
   /**
-   * extend fonts
+   * Extend fonts
+   * 扩展字体
    */
   fonts?: Record<string, string | string[]>;
 
+  /**
+   * The type of Chinese: "simplified" or "traditional".
+   * 中文的类型: "simplified"（简体）或 "traditional"（繁体）。
+   */
+  chineseType?: ChineseType;
+
+  /**
+   * Fallback font for Chinese characters.
+   * 备选字体。
+   */
+  fallbackFont?: string[] | null;
+
+  /**
+   * Declare fonts for English text.
+   * 声明英文文本的字体。
+   */
+  declareEnglishFont?: string[];
 }
+
+/**
+ * Represents different font types that can be used, including various Chinese fonts and styles.
+ * 表示可用的不同字体类型，包括各种中文字体和样式。
+ */
+export type FontType = "chinese" | "helvetica" | "italics" | "song" | "imitation-song" | "new-song" | "li";
+
+/**
+ * Represents different types of Chinese characters, such as simplified or traditional.
+ * 表示不同类型的中文字符，例如简体或繁体。
+ */
+export type ChineseType = "simplified" | "traditional";


### PR DESCRIPTION
## Proposed changes
This PR addresses issue #2 by providing a solution to render Chinese punctuation marks correctly by utilizing the unicode-range CSS descriptor. Currently, due to the arrangement of Western fonts before Chinese fonts in the generated CSS, Chinese punctuation marks like curved quotation marks, dashes, ellipses, and middle dots are displayed as Western glyphs. This behavior doesn't align with Chinese layout requirements.

The proposed solution takes inspiration from the `w3c/clreq` project, which uses the unicode-range descriptor to specify ranges of Unicode code points for different scripts in CSS, ensuring proper rendering of characters.

## Changes Made
- Introduced a function to dynamically calculate and set the required Chinese fonts based on the selected theme.
- Implemented CSS rules using `@font-face` with unicode-range descriptors for Chinese punctuation marks.
- Provided an example usage of the font setting function.


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Linked Issues
link #2 

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
