### PR TITLE
fix(typography): fix the language tag for Korean

### DIFF
--- a/src/typography/css/nonCjkBlock.ts
+++ b/src/typography/css/nonCjkBlock.ts
@@ -1,5 +1,5 @@
 import { isObject, serializeCSS } from "../../utils";
 
 export const getNonCjkBlockCss = (selectorName: string, css: Record<string, string> | string) => {
-  return `.${selectorName} em:not(:lang(zh)):not(:lang(ja)):not(:lang(kr)), .${selectorName} em:not(:lang(zh)) { ${isObject(css) ? serializeCSS(css) : css} }`;
+  return `.${selectorName} em:not(:lang(zh)):not(:lang(ja)):not(:lang(ko)), .${selectorName} em:not(:lang(zh)) { ${isObject(css) ? serializeCSS(css) : css} }`;
 };

--- a/src/typography/css/other.ts
+++ b/src/typography/css/other.ts
@@ -79,7 +79,7 @@ export const generateOtherCss = (selectorName: string) => {
   text-emphasis: filled circle;
   text-emphasis-position: under right;
 }
-.${selectorName} .${selectorName}-em:not(:lang(zh)):not(:lang(ja)):not(:lang(kr)), .${selectorName} .${selectorName}-em:not(:lang(zh)) {
+.${selectorName} .${selectorName}-em:not(:lang(zh)):not(:lang(ja)):not(:lang(ko)), .${selectorName} .${selectorName}-em:not(:lang(zh)) {
   -webkit-text-emphasis: none;
   text-emphasis: none;
 }

--- a/src/typography/css/other.ts
+++ b/src/typography/css/other.ts
@@ -1,4 +1,5 @@
 import { getVariables } from "./variables";
+import { getNonCjkBlockCss } from "./nonCjkBlock";
 
 export const generateOtherCss = (selectorName: string) => {
   return `
@@ -79,10 +80,10 @@ export const generateOtherCss = (selectorName: string) => {
   text-emphasis: filled circle;
   text-emphasis-position: under right;
 }
-.${selectorName} .${selectorName}-em:not(:lang(zh)):not(:lang(ja)):not(:lang(ko)), .${selectorName} .${selectorName}-em:not(:lang(zh)) {
-  -webkit-text-emphasis: none;
-  text-emphasis: none;
-}
+${getNonCjkBlockCss(`${selectorName}-em`, {
+    "-webkit-text-emphasis": "start",
+    "text-emphasis": "none",
+})}
 .${selectorName} .${selectorName}-ruby--inline {
   display: inline-flex;
   flex-direction: column-reverse;

--- a/src/typography/preflights/base.ts
+++ b/src/typography/preflights/base.ts
@@ -40,7 +40,7 @@ export const ChineseBase = {
     "text-align": "justify",
   },
 
-  "p:not(:lang(zh)):not(:lang(ja)):not(:lang(kr))": {
+  "p:not(:lang(zh)):not(:lang(ja)):not(:lang(ko))": {
     "text-align": "start",
   },
 

--- a/src/typography/preflights/base.ts
+++ b/src/typography/preflights/base.ts
@@ -40,10 +40,6 @@ export const ChineseBase = {
     "text-align": "justify",
   },
 
-  "p:not(:lang(zh)):not(:lang(ja)):not(:lang(ko))": {
-    "text-align": "start",
-  },
-
   "pre": {
     "margin-block-start": `calc(${getVariables.stdBlockUnit} * 0.5)`,
     "margin-block-end": `calc(${getVariables.stdBlockUnit} * 0.5)`,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/kirklin/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- Added necessary documentation (if appropriate)

-->
## Proposed changes

Fix the BCP 47 language tag for Korean.

It should be `ko` (search for "Korean" in https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry for details).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Linked Issues


## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
